### PR TITLE
Fix missing SEs and TVs

### DIFF
--- a/GWmodel/R/gwr.basic.r
+++ b/GWmodel/R/gwr.basic.r
@@ -105,8 +105,8 @@ gwr.basic <- function(formula, data, regression.points, bw, kernel="bisquare", a
   dp.n<-nrow(data)
   betas <- matrix(0, nrow=rp.n, ncol=var.n)
   if (hatmatrix) {
-    betas.SE <-matrix(nrow=rp.n, ncol=var.n)
-    betas.TV <-matrix(nrow=rp.n, ncol=var.n)
+    betas.SE <-matrix(0, nrow=rp.n, ncol=var.n)
+    betas.TV <-matrix(0, nrow=rp.n, ncol=var.n)
   }
   idx1 <- match("(Intercept)", colnames(x))
   if(!is.na(idx1))


### PR DESCRIPTION
As the matrices to store coefficient standard errors and t-values were prepopulated with NAs instead of 0s, they would always continue to be NA (values were later added through addition, but NA + some number = NA).

I did not check if a similar problem occurs in other parts of the code.